### PR TITLE
Johann fix grid render mobile width bug

### DIFF
--- a/styles/login-tabs-styles.css
+++ b/styles/login-tabs-styles.css
@@ -70,8 +70,15 @@ div[aria-hidden='true'] {
 */
 
 li a {
-  width: 80px;
+  width: 70px;
   height: auto;
+}
+
+@media screen and (min-width: 376px) {
+  li a {
+    width: 80px;
+    height: auto;
+  }
 }
 
 .tab::after {

--- a/styles/main.css
+++ b/styles/main.css
@@ -365,7 +365,6 @@ html {
 
 body {
   font-family: 'Avenir Light', Avenir Light, Arial, sans-serif;
-  min-width: 500px;
 }
 
 input {


### PR DESCRIPTION
Removed the max-width 500px from the body tag located in the center of our stylesheets. The app should render with the correct with on mobile now. Please test and give feedback. 

The nav should also fit on small mobile devises. 