### PR TITLE
Add retrieveMyDoWhops to onAuthStateChanged in login using person

### DIFF
--- a/scripts/login.js
+++ b/scripts/login.js
@@ -103,6 +103,7 @@ var person = null;
 auth.onAuthStateChanged(function(user) {
   if (user) {
     person = user;
+    retrieveMyDoWhops(person.uid);
   } else {
     console.log('PERSON signed out');
   }


### PR DESCRIPTION
We found a bug on IOS devices where MyDowhops were not retrieved on when using Safari. This should fix it. I deployed to Firebase. Please test to make sure DoWhopDescriptions are rendering on our phones. 