### PR TITLE
Added the classes and ids back to the creator review markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,7 +415,7 @@
                         <span class="mdl-textfield__error">Max characters for a comment is 140</span>
                       </div>
                       <div class="mdl-card__actions">
-                        <button class="btn btn-default">
+                        <button class="btn btn-default submit-comment creator" id="creator" ">
                           Submit
                         </button>
                       </div>


### PR DESCRIPTION
ID and classed were deleted on reviews -> creator -> comment -> submit
This caused a redirect 🐛  when you tried to leave a comment for creator. Easy fix but we need to be more careful with our code. 🕶 