### PR TITLE
restrict max height of messages div

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -802,7 +802,7 @@ button {
 }
 
 #create-outer-div {
-  text-align:center;
+  text-align: center;
   height: 50px;
   width: 300px;
 }
@@ -823,4 +823,12 @@ button {
   float: right;
   height: 50px;
   width: 50px;
+}
+
+/*------------------------------------*/
+/*-------------MESSAGES---------------*/
+/*------------------------------------*/
+
+#messages {
+  max-height: 900px;
 }


### PR DESCRIPTION
Rae wanted the max height of the messages div restricted. I want to check a few things on this before merging:

1. I set it to 900px. I want to check with Rae to fine tune height.
2. On Chrome the div is automatically scrolled to bottom if it's more than 900px, this is the desired behavior, but in testing, let's check if that is consistent across browsers.
3. And need to check if this is good on mobile, too.