### PR TITLE
change cursor to normal for verify. change default display to none an…

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -110,39 +110,39 @@
 
           <li class="mdl-list__item mdl-list__item--two-line">
             <span class="mdl-list__item-primary-content">
-              <i class="verify-phone-done check material-icons mdl-list__item-icon">done</i>
-              <i class="verify-phone-not-done material-icons mdl-list__item-icon">clear</i>
-              <i class="material-icons mdl-list__item-icon">phone</i>
+              <i class="verify-status-dependent verify-phone-done check material-icons mdl-list__item-icon">done</i>
+              <i class="verify-status-dependent verify-phone-not-done material-icons mdl-list__item-icon">clear</i>
+              <i class="verify-icon material-icons mdl-list__item-icon">phone</i>
               <span>Verify Phone</span>
-              <span class="verify-phone-done mdl-list__item-sub-title">Verified by DoWhop</span>
-              <span class="verify-phone-not-done mdl-list__item-sub-title">Pending Verification</span>
+              <span id="verify-item-1" class="verify-status-dependent verify-phone-done mdl-list__item-sub-title">Verified by DoWhop</span>
+              <span id="verify-item-2" class="verify-status-dependent verify-phone-not-done mdl-list__item-sub-title">Pending Verification</span>
             </span>
           </li>
           <li class="mdl-list__item mdl-list__item--two-line">
             <span class="mdl-list__item-primary-content">
-              <i class="verify-email-done check material-icons mdl-list__item-icon">done</i>
-              <i class="verify-email-not-done material-icons mdl-list__item-icon">clear</i>
-              <i class="material-icons mdl-list__item-icon">email</i>
+              <i class="verify-status-dependent verify-email-done check material-icons mdl-list__item-icon">done</i>
+              <i class="verify-status-dependent verify-email-not-done material-icons mdl-list__item-icon">clear</i>
+              <i class="verify-icon material-icons mdl-list__item-icon">email</i>
               <span>Verify Email</span>
-              <span class="verify-email-done mdl-list__item-sub-title">Verified by DoWhop</span>
-              <span class="verify-email-not-done mdl-list__item-sub-title">Pending Verification</span>
+              <span id="verify-item-3" class="verify-status-dependent verify-email-done mdl-list__item-sub-title">Verified by DoWhop</span>
+              <span id="verify-item-4" class="verify-status-dependent verify-email-not-done mdl-list__item-sub-title">Pending Verification</span>
             </span>
           </li>
           <li class="mdl-list__item mdl-list__item--two-line">
             <span class="mdl-list__item-primary-content">
-              <i class="verify-social-done check material-icons mdl-list__item-icon">done</i>
-              <i class="verify-social-not-done material-icons mdl-list__item-icon">clear</i>
-              <i class="material-icons mdl-list__item-icon">share</i>
+              <i class="verify-status-dependent verify-social-done check material-icons mdl-list__item-icon">done</i>
+              <i class="verify-status-dependent verify-social-not-done material-icons mdl-list__item-icon">clear</i>
+              <i class="verify-icon material-icons mdl-list__item-icon">share</i>
               <span>Verify Social</span>
-              <span class="verify-social-done mdl-list__item-sub-title">Verified by DoWhop</span>
-              <span class="verify-social-not-done mdl-list__item-sub-title">Pending Verification</span>
+              <span id="verify-item-5" class="verify-status-dependent verify-social-done mdl-list__item-sub-title">Verified by DoWhop</span>
+              <span id="verify-item-6" class="verify-status-dependent verify-social-not-done mdl-list__item-sub-title">Pending Verification</span>
             </span>    
           </li>
 
           <li class="mdl-list__item">
             <span class="mdl-list__item-primary-content">
               <i class="material-icons mdl-list__item-icon"></i>
-              <i class="material-icons mdl-list__item-icon">location_on</i>
+              <i class="verify-icon material-icons mdl-list__item-icon">location_on</i>
               <span>San Diego</span>
             </span>    
           </li>          

--- a/scripts/dowhop-profile-form-create.js
+++ b/scripts/dowhop-profile-form-create.js
@@ -122,14 +122,14 @@ function profileProgressUI() {
       var sections = ['verify-email', 'verify-phone', 'verify-social'];
       var className;
       sections.map(function(section) {
-        if (!profileProgress[section]) {
+        if (profileProgress[section]) {
           className = section + '-done';
         } else {
           className = section + '-not-done';
         }
         var elArr = document.getElementsByClassName(className);
         for (var i = 0; i < elArr.length; i++) {
-          elArr[i].style.display = 'none';
+          elArr[i].style.display = 'block';
         }
       });
     }

--- a/styles/main.css
+++ b/styles/main.css
@@ -862,6 +862,39 @@ button {
 }
 
 /*profile stuff to be moved later*/
+.verify-status-dependent {
+  display: none;
+  cursor: default !important;
+}
+
+.verify-icon {
+  cursor: default !important;
+}
+
+
+#verify-item-1 {
+  display: none;
+}
+
+#verify-item-2 {
+  display: none;
+}
+
+#verify-item-3 {
+  display: none;
+}
+
+#verify-item-4 {
+  display: none;
+}
+
+#verify-item-5 {
+  display: none;
+}
+
+#verify-item-6 {
+  display: none;
+}
 .check {
   color: #68b04d !important;
 }


### PR DESCRIPTION
This changes the default profile progress section behavior so that the UI loads in a better way. (checks and x's are hidden by default and then the "correct" one is shown. Rather than before where they both were shown and then the incorrect one was hidden). It will also fail more gracefully in the event that the logic to choose what to display cannot be executed. 